### PR TITLE
Document v3.1.0 user-facing features

### DIFF
--- a/docs/ChangelogFirmware.md
+++ b/docs/ChangelogFirmware.md
@@ -2,7 +2,7 @@
 
 ## v3.1.0 ##
 
-- **WiFi QR onboarding**: when WiFi is turned on the OLED shows a QR code so a phone can join the network and open the web page without typing the SSID, password or IP address. Works in both Access Point (two QR codes: join then open-page) and local-network (single open-page QR) modes. The QR dismisses itself once the web page actually loads, or with NEXT / SELECT.
+- **WiFi QR onboarding**: when WiFi is turned on the OLED shows a QR code so a phone can join the network and open the web page without typing the SSID, password or IP address. Works in both Access Point (two QR codes: join then open-page) and local-network (single open-page QR) modes. The QR dismisses itself once the web page actually loads, or with **NEXT** / **SELECT**.
 - **Interactive 3D survey view on the web interface**: the 2D `/View` map now has a **View in 3D** button that opens a full-screen 3D viewer. Orbit (left-drag / one-finger), dolly (right-drag), zoom (wheel / pinch) and click a station to re-centre on it. A base-plane grid and a compass-rose East/North/Up widget help with orientation.
 - **Depth-coloured survey paths**: the path on the web 2D map is now drawn as per-segment lines coloured by depth (**blue = deepest, red = highest**) instead of a near-invisible flat line. The on-device OLED depth gradient is reversed to match, so the on-device and web views share a single colour convention.
 - **Cleaner WiFi signal-strength icons**: the four RSSI icons on the OLED are now visibly distinct (regenerated at 16×16).

--- a/docs/ChangelogFirmware.md
+++ b/docs/ChangelogFirmware.md
@@ -1,5 +1,13 @@
 # Change Log Firmware
 
+## v3.1.0 ##
+
+- **WiFi QR onboarding**: when WiFi is turned on the OLED shows a QR code so a phone can join the network and open the web page without typing the SSID, password or IP address. Works in both Access Point (two QR codes: join then open-page) and local-network (single open-page QR) modes. The QR dismisses itself once the web page actually loads, or with NEXT / SELECT.
+- **Interactive 3D survey view on the web interface**: the 2D `/View` map now has a **View in 3D** button that opens a full-screen 3D viewer. Orbit (left-drag / one-finger), dolly (right-drag), zoom (wheel / pinch) and click a station to re-centre on it. A base-plane grid and a compass-rose East/North/Up widget help with orientation.
+- **Depth-coloured survey paths**: the path on the web 2D map is now drawn as per-segment lines coloured by depth (**blue = deepest, red = highest**) instead of a near-invisible flat line. The on-device OLED depth gradient is reversed to match, so the on-device and web views share a single colour convention.
+- **Cleaner WiFi signal-strength icons**: the four RSSI icons on the OLED are now visibly distinct (regenerated at 16×16).
+- **USB serial reliability**: a long-standing freeze caused by intermittent USB pogo-contact blips while the device was moved is fixed; the serial port stays stable when the device is jostled while connected, and `syncdatetime` no longer hangs if the host disconnects mid-transfer.
+
 ## v3.0.0 ##
 
 - **Multilingual UI**: on-device menus and messages are now available in English, Spanish, French, German, Simplified Chinese and Traditional Chinese. Language can be changed at any time in OPTIONS > SETTINGS > DEVICE SETTINGS > LANGUAGE.

--- a/docs/Survey-History.md
+++ b/docs/Survey-History.md
@@ -36,9 +36,32 @@ When a map is displayed — whether from History or from the BASIC mode shortcut
 
 ### 3D Map
 
-The 3D view renders the survey in perspective with depth-based colour (bright at the start, darker towards the end of the survey). Three reference axes are shown at the origin:
+The 3D view renders the survey in perspective with depth-based colour: **blue = deepest, red = highest** (since v3.1.0; the on-device gradient now matches the web view's). Three reference axes are shown at the origin:
 - **Yellow** arrow — vertical (UP)
 - **Red** arrow — North
 - **Blue** arrow — East
 
 The camera angle is controlled by the **IMU** — simply tilt and rotate the device to change the viewing direction. The camera framing adjusts automatically to fit the entire survey in view.
+
+---
+
+## Web Interface
+
+When connected over WiFi (see [Wireless Data Transfer](WIFI-Data-transfer.md)), every recorded survey can be viewed in your browser as well as on the OLED.
+
+### 2D survey map
+
+From the device's main web page, clicking a survey opens the `/View` page: a top-down SVG map of the survey path. *(v3.1.0+)* The path is drawn as per-segment lines coloured by depth — **blue = deepest, red = highest** — so it stands out clearly against the dark background. Stations are marked with circles (yellow at the start, red elsewhere).
+
+### Interactive 3D viewer *(v3.1.0+)*
+
+On the 2D map page a **▶ View in 3D** button opens `/View3D`, a full-screen interactive 3D viewer of the same survey. Controls:
+
+| Action | Mouse | Touch |
+| --- | --- | --- |
+| Orbit | Left-drag | One-finger drag |
+| Dolly (camera distance) | Right-drag up/down | — |
+| Zoom | Scroll wheel | Pinch |
+| Re-centre on a station | Click the station | Tap the station |
+
+A base-plane grid is drawn at the deepest survey point, and a small compass-rose axes widget (East / North / Up) sits in the lower-left corner. Use the **← 2D** link at the top-left to return to the 2D map.

--- a/docs/WIFI-Data-transfer.md
+++ b/docs/WIFI-Data-transfer.md
@@ -56,6 +56,25 @@ When enabled, the device will automatically attempt to connect to a known networ
 
 ---
 
+## WiFi QR onboarding *(v3.1.0+)*
+
+When you turn WiFi on the Mnemo shows a **QR code** on the OLED so you don't have to type the network name, password or IP address on your phone.
+
+### Local network (WIFI ON/OFF)
+
+Once the Mnemo connects to your network it shows a QR code containing the page address (`http://<device-ip>`). Open your phone or computer's camera, point it at the screen, and tap the prompt to open the Mnemo's web page directly.
+
+### Access Point (WIFI AP)
+
+In AP mode the onboarding happens in two stages:
+
+1. **Join QR** — encodes the AP credentials (`SSID: Mnemo`, `Password: password`). Point your phone's camera at it and tap the prompt to join the Mnemo's network — no typing.
+2. **Open-page QR** — appears automatically once your phone associates with the AP. Scan it to open the Mnemo's page in the browser. The QR dismisses itself the moment the page actually loads, returning the OLED to its normal screen.
+
+You can dismiss either QR at any time with the device's **NEXT** or **SELECT** buttons.
+
+---
+
 ## The Mnemo as Wireless Access Point
 
 If your local network is not accessible you can configure the MNemo as a Wireless Access Point.

--- a/docs/WIFI-Data-transfer.md
+++ b/docs/WIFI-Data-transfer.md
@@ -52,7 +52,9 @@ Open a browser and navigate to the displayed IP address to preview surveys or do
 
 Navigate to **OPTIONS > WIFI > WIFI ON AT START** and toggle the option on.
 
-When enabled, the device will automatically attempt to connect to a known network every time it powers on — no manual menu navigation needed.
+When enabled, the device automatically starts its **WiFi Access Point** every time it powers on. The Access Point shuts itself off after **30 seconds** if no one connects to it, so it doesn't drain the battery when unused.
+
+> Combined with the QR onboarding below, this makes opening the Mnemo's web page on your phone right after switching the device on a two-scan operation.
 
 ---
 

--- a/docs/WIFI-Data-transfer.md
+++ b/docs/WIFI-Data-transfer.md
@@ -58,7 +58,7 @@ When enabled, the device will automatically attempt to connect to a known networ
 
 ## WiFi QR onboarding *(v3.1.0+)*
 
-When you turn WiFi on the Mnemo shows a **QR code** on the OLED so you don't have to type the network name, password or IP address on your phone.
+When you turn WiFi on, the Mnemo shows a **QR code** on the OLED so you don't have to type the network name, password or IP address on your phone.
 
 ### Local network (WIFI ON/OFF)
 

--- a/docs/WIFI-Data-transfer.md
+++ b/docs/WIFI-Data-transfer.md
@@ -62,7 +62,7 @@ When you turn WiFi on, the Mnemo shows a **QR code** on the OLED so you don't ha
 
 ### Local network (WIFI ON/OFF)
 
-Once the Mnemo connects to your network it shows a QR code containing the page address (`http://<device-ip>`). Open your phone or computer's camera, point it at the screen, and tap the prompt to open the Mnemo's web page directly.
+Once the Mnemo connects to your network it shows a QR code containing the page address (`http://<device-ip>`). Open your phone or computer camera app, point it at the screen, and tap the prompt to open the Mnemo's web page directly.
 
 ### Access Point (WIFI AP)
 


### PR DESCRIPTION
## Summary

Closes a gap in the user manual after firmware **v3.1.0** shipped on 2026-05-23. Three of the new release's user-facing features were not described anywhere on https://sebkister.github.io/MNemoV2-Documentation/, and the *WiFi at Start* description was inaccurate.

## What changed

- **`docs/WIFI-Data-transfer.md`** —
  - Fixes the *WiFi at Start* section: it actually starts the **WiFi Access Point** for 30 seconds on boot (confirmed against `main.cpp:285-292` — `wiFiMode = WIFI_AP; startServerWifi(); wifiDisconnectTask.enableDelayed(30000)`). The page previously said it auto-connected to a known network, which never matched the code. The v3.0.0 changelog entry on this page had it right all along.
  - Adds a new *WiFi QR onboarding (v3.1.0+)* section covering both flows:
    - Local network (WIFI ON/OFF): single open-page QR with the device's IP.
    - Access Point (WIFI AP): two-stage **Join QR → Open-page QR**, with the auto-dismiss behaviour and NEXT/SELECT manual dismissal.
- **`docs/Survey-History.md`**:
  - Fixes the on-device 3D depth-colour description (was *bright at start, darker towards end* — hadn't matched the implementation for a while; v3.1.0 standardises on **blue = deepest, red = highest** to match the web view).
  - Adds a new **Web Interface** section describing the web `/View` 2D depth-coloured map and the new interactive `/View3D` viewer with a mouse/touch controls table and a note about the base-plane grid and compass-rose axes widget.
- **`docs/ChangelogFirmware.md`** — appends a **v3.1.0** entry at the top covering: WiFi QR onboarding, the web 3D view, depth-coloured maps, the regenerated 16×16 RSSI icons, and the USB serial reliability fix.

## Why now

Firmware release v3.1.0 (https://github.com/Ariane-s-Line/Mnemo-V2-Releases/releases/tag/v3.1.0) ships features users will discover and need to be guided through — especially the QR onboarding, which materially changes the *"how do I get my phone on the Mnemo's WiFi?"* answer.

## Notes

- No new screenshots (`/img/...`) added — the new sections are pure prose. Screenshots of the two QR screens and the 3D viewer can be added in a follow-up once captures are available.
- No pages were renamed or restructured; all edits are additive within the existing section layouts (plus the *WiFi at Start* correction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)